### PR TITLE
Update init.brcm.wifibt.8qxp.sh

### DIFF
--- a/imx8q/som_mx8q/init.brcm.wifibt.8qxp.sh
+++ b/imx8q/som_mx8q/init.brcm.wifibt.8qxp.sh
@@ -127,28 +127,10 @@ wifi_down()
 	echo 0 > /sys/class/gpio/gpio${WIFI_3V3_GPIO}/value
 }
 
-# Return true if SOM has WIFI module assembled
-wifi_is_available()
-{
-	# Read SOM options EEPROM field
-	opt=$(/system/bin/i2cget -f -y 0x0 0x52 0x20)
-
-	# Check WIFI bit in SOM options
-	if [ $((opt & 0x1)) -eq 1 ]; then
-		return 0
-	else
-		return 1
-	fi
-}
 
 # Return true if WIFI should not be started
 wifi_should_not_be_started()
 {
-	# Do not enable WIFI if it's not available
-	if ! wifi_is_available; then
-		return 0
-	fi
-
 	# Do not enable WIFI if it is already up
 	[ -d /sys/class/net/wlan0 ] && return 0
 
@@ -163,10 +145,6 @@ wifi_should_not_be_started()
 # Return true if WIFI should not be stopped
 wifi_should_not_be_stopped()
 {
-	# Do not stop WIFI if it's not available
-	if ! wifi_is_available; then
-		return 0
-	fi
 
 	# Do not stop WIFI if booting from eMMC without WIFI
 	if ! grep -q WIFI /sys/devices/soc0/machine; then


### PR DESCRIPTION
No EEPROM available on this SOM. So wifi availability is always false.